### PR TITLE
feat: create endpoint to upload doc and return publicly accessible url

### DIFF
--- a/src/api/custom-upload/controllers/custom-upload.js
+++ b/src/api/custom-upload/controllers/custom-upload.js
@@ -1,0 +1,32 @@
+module.exports = {
+  async uploadFile(ctx) {
+    try {
+      const { files } = ctx.request; // Get the uploaded file
+
+      if (!files || !files.file) {
+        return ctx.badRequest("No file provided");
+      }
+
+      // Use Strapi's Media Library Plugin for file upload
+      const uploadedFiles = await strapi
+        .plugin("upload")
+        .service("upload")
+        .upload({
+          data: {}, // Optional metadata
+          files: files.file, // The uploaded file
+        });
+
+      if (!uploadedFiles || uploadedFiles.length === 0) {
+        return ctx.internalServerError("File upload failed");
+      }
+
+      return ctx.send({
+        message: "File uploaded successfully",
+        fileUrl: uploadedFiles[0].url, // File URL
+      });
+    } catch (error) {
+      console.error("Upload error:", error);
+      return ctx.internalServerError("File upload failed");
+    }
+  },
+};

--- a/src/api/custom-upload/routes/custom-upload.js
+++ b/src/api/custom-upload/routes/custom-upload.js
@@ -1,0 +1,13 @@
+module.exports = {
+  routes: [
+    {
+      method: "POST",
+      path: "/custom-upload",
+      handler: "custom-upload.uploadFile",
+      config: {
+        auth: false, // Change to true if authentication is required
+        policies: [],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Below is the curl to use the API

```
curl --location 'http://localhost:1337/api/custom-upload' \
--form 'file=@"/Users/ajay/Downloads/strapi-2025-02-11.sql"'
```